### PR TITLE
Support creating nested resource in one mutation

### DIFF
--- a/src/buildVariables.js
+++ b/src/buildVariables.js
@@ -232,7 +232,7 @@ const buildCreateVariables = introspectionResults => (resource, aorFetchType, pa
 
       // If no fields in the object are valid, continue
       if (Object.keys(fieldsToConnect).length === 0) {
-        return acc;
+        return { ...acc, data: { ...acc.data, [key]: params.data[key] } };
       }
 
       // Else, connect the nodes


### PR DESCRIPTION
Suppose we have two resources, `post` and `question`, where one post contains multiple questions. We want to create questions in the post create form. Following is the code.

```
export const PostCreate = (props) => (
    <Create {...props}>
        <SimpleForm redirect="show">
            <ReferenceInput source="agent.id" reference="Agent">
                <SelectInput optionText="name"/>
            </ReferenceInput>
            <TextInput source="title"/>
            <LongTextInput source="content"/>
            <ArrayInput source="questions.create" label="resources.Post.fields.questions">
                <SimpleFormIterator>
                    <TextInput source="title" label="resources.Question.fields.title"/>
                </SimpleFormIterator>
            </ArrayInput>
        </SimpleForm>
    </Create>
);
```

The magic here is the `source="questions.create"`, which will map the array to a corresponding object in the mutation variable.

But this does not work with the current version. Rather, a simple fix is done here.

This PR also fixes the issue of `DELETE_MANY` and `UPDATE_MANY` not working.